### PR TITLE
Using Math.min makes fontResize var needless

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -14,9 +14,9 @@
 	$.fn.fitText = function( kompressor ) {
 	
 			return this.each(function(){
-				var $this = $(this);                         // store the object
-				var origFontSize = $this.css('font-size');   // init the font sizes
-				var compressor = kompressor || 1;            // set the compressor
+				var $this = $(this);                                     // store the object
+				var origFontSize = parseFloat($this.css('font-size'));   // init the font sizes
+				var compressor = kompressor || 1;                        // set the compressor
 
         // Resizer() resizes items based on the object width divided by the compressor * 10
 				var resizer = function () {


### PR DESCRIPTION
The comparison with the ternary operator is unnecessary, if you use the built-in Math.min function. Then you can even completely skip var fontResize.

The resizer function also doesn't need the "obj" variable, since it always points to $this.
