### PR TITLE
Ender.js compatibility

### DIFF
--- a/fittext.js
+++ b/fittext.js
@@ -1,4 +1,4 @@
-/*global jQuery */
+/*global jQuery or Ender */
 /*!	
 * FitText.js 1.0
 *


### PR DESCRIPTION
I added [Ender.js](http://ender.no.de) compatibility to fittext, and renamed the file to fittext.js, since it is no longer jQuery exclusive.  Feel free to just cherry-pick first commit if you don't want the file's name to be changed, for some reason.
