### PR TITLE
Allow me to undo the fittext

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ FitText now allows you to specify two optional pixel values: `minFontSize` and `
 
     $("#responsive_headline").fitText(1.2, { minFontSize: '20px', maxFontSize: '40px' })
 
+### Resetting
+You can reset all fitted text so that it will fallback to CSS defaults by triggering the "fittext-reset" event.
+
+    $(document).trigger("fittext-reset");
+
 ## CSS Tips
 
 * Make sure your headline is `display: block;` or 	`display: inline-block;` with a specified width, i.e. `width: 100%`. 

--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -1,65 +1,60 @@
 /*global jQuery */
 /*!	
- * FitText.js 1.0
- *
- * Copyright 2011, Dave Rupert http://daverupert.com
- * Released under the WTFPL license 
- * http://sam.zoy.org/wtfpl/
- *
- * Date: Thu May 05 14:23:00 2011 -0600
- */
+* FitText.js 1.0
+*
+* Copyright 2011, Dave Rupert http://daverupert.com
+* Released under the WTFPL license 
+* http://sam.zoy.org/wtfpl/
+*
+* Date: Thu May 05 14:23:00 2011 -0600
+*/
 
 (function( $ ){
-  var resizeOccurred = true;
-
-  function setup_throttle() {
-    $(window).resize(function() {
-      resizeOccurred = true;
-    });
-
-    window.setInterval(function() {
-      if(resizeOccurred) {
-        resizeOccurred = false;
-        $(document).trigger("fittext-resize");
-      }
-    }, 300);
-
-    setup_throttle = function() {};
-  }
-
-  $.fn.fitText = function( kompressor, options ) {
-    var settings = {
-      'minFontSize' : Number.NEGATIVE_INFINITY,
-      'maxFontSize' : Number.POSITIVE_INFINITY
-    };
-
-    return this.each(function(){
-      var $this = $(this);              // store the object
-      var compressor = kompressor || 1; // set the compressor
-      if ( options ) { 
-         $.extend( settings, options );
-      }
-
-      setup_throttle();
-
-      // Resizer() resizes items based on the object width divided by the compressor * 10
-      var resizer = function () {
-        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+    function setup_listener() {
+        $(window).resize(function() {
+            $(document).trigger("fittext-resize");
+        });
+        // only once
+        setup_listener = function(){};
+    }
+	$.fn.fitText = function( kompressor, options ) {
+	    
+	    var settings = {
+        'minFontSize' : Number.NEGATIVE_INFINITY,
+        'maxFontSize' : Number.POSITIVE_INFINITY
       };
 
-      // Call once to set.
-      resizer();
+      setup_listener();
+	
+			return this.each(function(){
+				var $this = $(this);              // store the object
+				var compressor = kompressor || 1; // set the compressor
+        
+        if ( options ) { 
+          $.extend( settings, options );
+        }
+        
+        // Resizer() resizes items based on the object width divided by the compressor * 10
+				var resizer = function () {
+					$this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+				};
+      // resetter() wipes out inline fonts and stops listening
+        var resetter = function() {
+            var style = $this.attr("style");
+            $this.attr("style", style.replace(/font-size:.*?;/, ""));
+            $(document).unbind("fittext-resize", resizer);
+            $(document).unbind("fittext-reset", resetter);
+        };
 
-      var resetter = function() {
-        var style = $this.attr("style");
-        $this.attr("style", style.replace(/font-size:.*?;/, ""));
-        $(document).unbind("fittext-resize", resizer);
-        $(document).unbind("fittext-reset", resetter);
-      };
+				// Call once to set.
+				resizer();
+				
+				// Call on resize. Opera debounces their resize by default. 
+      	$(document).bind("fittext-resize", resizer);
+      	$(document).bind("fittext-reset", resetter);
+      	
+			});
 
-      $(document).bind("fittext-resize", resizer);
-      $(document).bind("fittext-reset", resetter);
-    });
-  };
+	};
 
 })( jQuery );


### PR DESCRIPTION
I was using this today and found that I really only needed to apply FitText at a certain breakpoint. 

This change allowed me to move freely between breakpoints, without having to fight with super-specific inline style rules. 
