### PR TITLE
Update jquery.fittext.js

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -17,7 +17,8 @@
     var compressor = kompressor || 1,
         settings = $.extend({
           'minFontSize' : Number.NEGATIVE_INFINITY,
-          'maxFontSize' : Number.POSITIVE_INFINITY
+          'maxFontSize' : Number.POSITIVE_INFINITY,
+          'parameter': 'font-size'
         }, options);
 	
     return this.each(function(){
@@ -27,7 +28,7 @@
         
       // Resizer() resizes items based on the object width divided by the compressor * 10
       var resizer = function () {
-        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+        $this.css(settings.parameter, Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
       };
 
       // Call once to set.


### PR DESCRIPTION
With this change, script can be apply to block elements.
Example invoke:
$("img").fitText(1.2, {parameter:'width' });
