### PR TITLE
Class of 'fittexted' is added to elements affected

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -28,6 +28,7 @@
       // Resizer() resizes items based on the object width divided by the compressor * 10
       var resizer = function () {
         $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+        $this.addClass('fittexted');
       };
 
       // Call once to set.


### PR DESCRIPTION
This is used so you can have pre- and post-fittext styles (e.g. hide until fittexted and then show)
