### PR TITLE
Add event namespace so .off('.FitText') can be called for responsive sites.

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -34,7 +34,7 @@
       resizer();
 
       // Call on resize. Opera debounces their resize by default.
-      $(window).on('resize.FitText orientationchange.FitText', resizer);
+      $(window).on('resize.fittext orientationchange.fittext', resizer);
 
     });
 


### PR DESCRIPTION
Event namespace added so `$(window).off('.FitText');` can be called.

**Use case**: responsive site that needs FitText in one breakpoint but not another one.

I'm using enquire.js to call `$myElement.fitText();` in one breakpoint, then `$(window).off('.FitText');` in another.
