### PR TITLE
JQuery 1.4.2 and FitText fails to update text size on orientation change...

### DIFF
--- a/example.html
+++ b/example.html
@@ -48,7 +48,7 @@
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 	</div>
 	
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
  	<script src="jquery.fittext.js"></script>
 	<script type="text/javascript">
 		$("#fittext1").fitText();

--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -34,7 +34,7 @@
       resizer();
 
       // Call on resize. Opera debounces their resize by default.
-      $(window).on('resize.fittext orientationchange.fittext', resizer);
+      $(window).bind('resize.fittext orientationchange.fittext', resizer);
 
     });
 


### PR DESCRIPTION
....  $(window).on causes FitText to throw the js error: "TypeError: 'undefined' is not a function (evaluating '$(window).on('resize.fittext orientationchange.fittext', resizer)')".  $(window).bind does not and is compatible with jQuery 1.0/
