### PR TITLE
Possibility to set compressor ratios individually for every element

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -24,10 +24,13 @@
 
       // Store the object
       var $this = $(this);
+      
+      // Set particular compressor for the object according to its data value
+      var compressator = $this.data('fittext-kompressor') || compressor;
 
       // Resizer() resizes items based on the object width divided by the compressor * 10
       var resizer = function () {
-        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+        $this.css('font-size', Math.max(Math.min($this.width() / (compressator*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
       };
 
       // Call once to set.


### PR DESCRIPTION
By setting data-fittext-kompressor attribute. 
For example, data-fittext-kompressor="0.5" sets compressor value for the element to 0.5
