### PR TITLE
Added resizeModifier for selectively adding or removing specific fitText() calls

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -17,7 +17,8 @@
     var compressor = kompressor || 1,
         settings = $.extend({
           'minFontSize' : Number.NEGATIVE_INFINITY,
-          'maxFontSize' : Number.POSITIVE_INFINITY
+          'maxFontSize' : Number.POSITIVE_INFINITY,
+          'resizeModifier' : ''
         }, options);
 
     return this.each(function(){
@@ -33,8 +34,12 @@
       // Call once to set.
       resizer();
 
+      if (settings.resizeModifier && settings.resizeModifier.length > 0) {
+        settings.resizeModifier = '.' + settings.resizeModifier
+      }
+
       // Call on resize. Opera debounces their resize by default.
-      $(window).on('resize.fittext orientationchange.fittext', resizer);
+      $(window).on('resize.fittext' + settings.resizeModifier + ' orientationchange.fittext' + settings.resizeModifier, resizer);
 
     });
 


### PR DESCRIPTION
Helps with responsive designs where at certain breakpoints the resize operation should no longer take place regardless of a minimum or maximum font-size.
