### PR TITLE
Added smart detection for the font size

### DIFF
--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -23,18 +23,24 @@
     return this.each(function(){
 
       // Store the object
-      var $this = $(this);
+      var $this = $(this), 
+          wlength = $this.text().length || 1,
+          size = ($this.width() / wlength / compressor < $this.height() / compressor) ? $this.width() / wlength / compressor : $this.height() / compressor;
+      
 
-      // Resizer() resizes items based on the object width divided by the compressor * 10
+      // Resizer() resizes items based on the object width divided by 
+      // total character found in the element and divided again with the total paragraph line
+      // or using object height divided by paragraph line
       var resizer = function () {
-        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+        $this.css('font-size', Math.max(Math.min(size, parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
       };
 
       // Call once to set.
       resizer();
 
       // Call on resize. Opera debounces their resize by default.
-      $(window).on('resize.fittext orientationchange.fittext', resizer);
+      $(window)
+        .on('resize.fittext orientationchange.fittext', resizer);
 
     });
 


### PR DESCRIPTION
Added a simple logic to determine the font size, while the old styles using "compressor", the new logic uses width divided by total character divided by compressor (expected paragraph line in the box) or height divided by the compressor - whichever is smallest will be used.
