### PR TITLE
Add spacing option for proportional letter spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ FitText now allows you to specify two optional pixel values: `minFontSize` and `
 jQuery("#responsive_headline").fitText(1.2, { minFontSize: '20px', maxFontSize: '40px' });
 ```
 
+## Letter spacing
+The `spacing` option allows you to specify a value between `0` (default) and `1` which will add a letter spacing proportional to the size calculated by FitText. 
+
+```javascript
+jQuery("#responsive_headline").fitText(1.2, { spacing: 0.3 }); // Letter spacing will be 30% of the calculated size
+```
+
 ## CSS FAQ
 
 - **Make sure your container has a width!**

--- a/example.html
+++ b/example.html
@@ -44,6 +44,7 @@
 		<h1 id="fittext1">Squeeze with FitText</h1>
 		<h1 id="fittext2">Squeeze with FitText</h1>
 		<h1 id="fittext3">Squeeze with FitText</h1>
+		<h1 id="fittext4">Squeeze with FitText</h1>
 		</header>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
 	</div>
@@ -54,6 +55,7 @@
 		$("#fittext1").fitText();
 		$("#fittext2").fitText(1.2);
 		$("#fittext3").fitText(1.1, { minFontSize: '50px', maxFontSize: '75px' });
+		$("#fittext4").fitText(1.1, { spacing: 0.3 });
 	</script>
 	
 </body>

--- a/jquery.fittext.js
+++ b/jquery.fittext.js
@@ -17,7 +17,8 @@
     var compressor = kompressor || 1,
         settings = $.extend({
           'minFontSize' : Number.NEGATIVE_INFINITY,
-          'maxFontSize' : Number.POSITIVE_INFINITY
+          'maxFontSize' : Number.POSITIVE_INFINITY,
+          'spacing'     : 0
         }, options);
 
     return this.each(function(){
@@ -25,9 +26,10 @@
       // Store the object
       var $this = $(this);
 
-      // Resizer() resizes items based on the object width divided by the compressor * 10
+      // Resizer() resizes items based on the object width divided by the compressor * 10     
       var resizer = function () {
-        $this.css('font-size', Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize)));
+        var size = Math.max(Math.min($this.width() / (compressor*10), parseFloat(settings.maxFontSize)), parseFloat(settings.minFontSize))
+        $this.css({ 'font-size': size, 'letter-spacing': Math.floor(size * settings.spacing) });
       };
 
       // Call once to set.


### PR DESCRIPTION
Currently maintaining a letter spacing in px for headlines with FitText is a little tricky at extreme resolution. I've added an option allowing to specify a spacing proportional to the font-size so that it always looks neatly spaced.
Let me know if there are any changes required for merging.